### PR TITLE
Removed Smoke Tests

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,5 +8,3 @@ RANCHER_SECRET_KEY=${RANCHER_SECRET_KEY:?"Need to set RANCHER_SECRET_KEY"}
 SMOKE_TEST_URL=${SMOKE_TEST_URL:?"Need to set SMOKE_TEST_URL"}
 
 rancher-compose -p $PROJECT_NAME --url $RANCHER_SERVER_URL --access-key $RANCHER_ACCESS_KEY --secret-key $RANCHER_SECRET_KEY --debug up -u -c -p -d  || exit $?
-sleep 10
-smoke-tests/check_running.sh $SMOKE_TEST_URL || exit $?


### PR DESCRIPTION
Until we have a requirement to access the ontologies externally I'm removing these tests
